### PR TITLE
cleanup package hierarchy

### DIFF
--- a/src/main/kotlin/org/pareto/music/Music.kt
+++ b/src/main/kotlin/org/pareto/music/Music.kt
@@ -10,7 +10,7 @@ infix fun Music?.or  (that: Music?) = Decision(this, that)
 
 /**
  * A container for various process types.  Each subtype can be represented
- * in a "canonical" form by calling [Music.canonical].
+ * in a "canonical" form by calling [Music].canonical.
  *
  * Consider the following representation of a grammar describing dice rolls:
  *
@@ -160,31 +160,10 @@ sealed class Dimension(
     ) : Dimension(Front, Back)
 }
 
-/**
- * Produces a canonical, language-agnostic string representation of this process.
- */
-fun Music?.canonical(): String = when (this) {
-    null ->          "[ ]"
-    is Dimension.Choice -> when(Wont) {
-               // this indicates "Optional" Music
-               null ->  "[ ${Will.canonical()} ]"
-                  else ->   "${Will.canonical()} | ${Wont.canonical()}" }
-    is Dimension.Space ->  "${Front.canonical()} & ${Back.canonical()}"
-    is Dimension.Time ->    "${Tick.canonical()} > ${Tock.canonical()}"
-    is Fn.Definition -> { if (requiredArgs.isNotEmpty())
-        "$name(${requiredArgs.joinToString()})\n  : ${music.canonical()}"
-        else "$name\n  : ${music.canonical()}"
-    }
-
-    is Fn.Call -> { if (params.isNotEmpty())
-        "$name(${params.joinToString { it.canonical() }})"
-        else "$name" }
-    is Note ->             name.toString()
-}
 
 fun Music?.rebuildWithReplacements(replacements: Map<Note.Name, Music?>, namespace: FunctionNamespace<Fn.Definition>): Music? {
     return when(this) {
-        null -> null
+        Silence -> Silence
         is Note -> replacements[this.name] ?: this
         is Fn.Call -> namespace[name]?.replacingArgsWith(params, namespace)?.rebuildWithReplacements(replacements, namespace) ?: throw UnrunnableProcess("name $name does not exist in namespace")
         is Decision -> Decision(Will.rebuildWithReplacements(replacements, namespace), Wont.rebuildWithReplacements(replacements, namespace))

--- a/src/main/kotlin/org/pareto/music/Types.kt
+++ b/src/main/kotlin/org/pareto/music/Types.kt
@@ -2,6 +2,8 @@
 
 package org.pareto.music
 
+import org.pareto.music.canon.canonical
+
 /**
  * We separate [String]s into [Text.PascalCase]s and [Text.nonPascalCase]s.
  */

--- a/src/main/kotlin/org/pareto/music/canon/Canonical.kt
+++ b/src/main/kotlin/org/pareto/music/canon/Canonical.kt
@@ -1,0 +1,28 @@
+package org.pareto.music.canon
+
+import org.pareto.music.Dimension
+import org.pareto.music.Fn
+import org.pareto.music.Music
+import org.pareto.music.Note
+
+/**
+ * Produces a canonical, language-agnostic string representation of this process.
+ */
+fun Music?.canonical(): String = when (this) {
+    null ->          "[ ]"
+    is Dimension.Choice -> when(Wont) {
+        // this indicates "Optional" Music
+        null ->  "[ ${Will.canonical()} ]"
+        else ->   "${Will.canonical()} | ${Wont.canonical()}" }
+    is Dimension.Space ->  "${Front.canonical()} & ${Back.canonical()}"
+    is Dimension.Time ->    "${Tick.canonical()} > ${Tock.canonical()}"
+    is Fn.Definition -> { if (requiredArgs.isNotEmpty())
+        "$name(${requiredArgs.joinToString()})\n  : ${music.canonical()}"
+    else "$name\n  : ${music.canonical()}"
+    }
+
+    is Fn.Call -> { if (params.isNotEmpty())
+        "$name(${params.joinToString { it.canonical() }})"
+    else "$name" }
+    is Note ->             name.toString()
+}

--- a/src/main/kotlin/org/pareto/music/canon/README.md
+++ b/src/main/kotlin/org/pareto/music/canon/README.md
@@ -1,0 +1,3 @@
+# `music.canon`
+
+This package contains the standard library and tools for composing `music`.

--- a/src/main/kotlin/org/pareto/music/canon/StdLib.kt
+++ b/src/main/kotlin/org/pareto/music/canon/StdLib.kt
@@ -1,6 +1,18 @@
 @file:Suppress("FunctionName", "MemberVisibilityCanBePrivate")
 
-package org.pareto.music
+package org.pareto.music.canon
+
+import org.pareto.music.Decision
+import org.pareto.music.Fn
+import org.pareto.music.Grammar
+import org.pareto.music.Harmony
+import org.pareto.music.Melody
+import org.pareto.music.Music
+import org.pareto.music.Note
+import org.pareto.music.Silence
+import org.pareto.music.and
+import org.pareto.music.or
+import org.pareto.music.then
 
 object StdLib {
 
@@ -27,7 +39,7 @@ object StdLib {
     /**
      * grace note to make your DSL grammars look nice <3
      */
-    val process = Note.Name("process")
+    val music = Note.Name("music")
 
     /**
      * The [StandardGrammar] is prepended to every grammar built with the DSL.
@@ -64,33 +76,58 @@ object StdLib {
     val StandardGrammar: Grammar = Grammar(
         // this isn't pretty, but no need to depend on the DSL in this package.
         listOf(
+            /**
+             * Possible(music) {
+             *   music or Silence
+             * }
+             */
             Fn.Definition(
                 Fn.Name(Possible),
                 Decision(
-                    Note(process),
-                    null),
-                listOf(process)),
+                    Note(music),
+                    Silence),
+                listOf(music)),
+            /**
+             * Repeating(music) {
+             *   music then Repeating(music)
+             * }
+             */
             Fn.Definition(
                 Fn.Name(Repeating),
                 Melody(
-                    Note(process),
+                    Note(music),
                     Fn.Call(
                         Fn.Name(Repeating),
                         listOf(
-                            Note(process)))),
-                listOf(process)),
+                            Note(music)
+                        ))
+                ),
+                listOf(music)),
+            /**
+             * OneOrMore(music) {
+             *   music then Possible(OneOrMore(music))
+             * }
+             */
             Fn.Definition(
                 Fn.Name(OneOrMore),
                 Melody(
-                    Note(process),
+                    Note(music),
                     Fn.Call(
                         Fn.Name(Possible),
                         listOf(
                             Fn.Call(
                                 Fn.Name(OneOrMore),
                                 listOf(
-                                    Note(process)))))),
-                listOf(process)),
+                                    Note(music)
+                                ))
+                        ))
+                ),
+                listOf(music)),
+            /**
+             * ZeroOrMore(music) {
+             *   Possible(OneOrMore(music))
+             * }
+             */
             Fn.Definition(
                 Fn.Name(ZeroOrMore),
                 Fn.Call(
@@ -99,8 +136,11 @@ object StdLib {
                         Fn.Call(
                             Fn.Name(OneOrMore),
                             listOf(
-                                Note(process))))),
-                listOf(process))))
+                                Note(music)
+                            ))
+                    )),
+                listOf(music))
+        ))
 
     /**
      * A Possible process can be skipped or evaluated at runtime.
@@ -127,7 +167,7 @@ object StdLib {
     fun ZeroOrMore(music: Music): Decision = Possible(OneOrMore(music))
 
     /**
-     * Converts a [Sound] into 1 or more concurrent copies of itself.
+     * Converts a [Music] into 1 or more concurrent copies of itself.
      */
     @Suppress("Unused")
     fun Multiple(music: Music): Harmony = music and Possible(Multiple(music))

--- a/src/main/kotlin/org/pareto/music/demo/README.md
+++ b/src/main/kotlin/org/pareto/music/demo/README.md
@@ -1,0 +1,3 @@
+# `music.demo`
+
+This package contains example use cases for `Music`. These subpackages should be standalone and should not be internally imported. Think of them as lightweight little product demos and please add more!

--- a/src/main/kotlin/org/pareto/music/demo/madlibs/MadLibs.kt
+++ b/src/main/kotlin/org/pareto/music/demo/madlibs/MadLibs.kt
@@ -1,7 +1,7 @@
 package org.pareto.music.demo.madlibs
 
 import org.pareto.music.Grammar
-import org.pareto.music.compose
+import org.pareto.music.canon.compose
 import org.pareto.music.perform.Decider
 import org.pareto.music.perform.StringBuilderPerformer
 

--- a/src/main/kotlin/org/pareto/music/perform/Performer.kt
+++ b/src/main/kotlin/org/pareto/music/perform/Performer.kt
@@ -8,6 +8,7 @@ import org.pareto.music.Harmony
 import org.pareto.music.Melody
 import org.pareto.music.Music
 import org.pareto.music.Note
+import org.pareto.music.Silence
 import org.pareto.music.UnrunnableProcess
 
 

--- a/src/main/kotlin/org/pareto/music/perform/README.md
+++ b/src/main/kotlin/org/pareto/music/perform/README.md
@@ -1,0 +1,15 @@
+# `music.perform`
+
+This package contains tools for directly running (or "performing") `music` programs without first compiling them.
+
+If you wanted to assign a thematically-correct type signature to this package, it would be:
+
+```kotlin
+typealias Performable = (Music) -> Any?
+```
+
+You can contrast this with the [music.rehearse](../rehearse) package, which contains an intermediate compilation step before running `music`:
+
+```kotlin
+typealias Rehearsable<T> = (Music) -> (T) -> Any?
+```

--- a/src/main/kotlin/org/pareto/music/rehearse/Compiler.kt
+++ b/src/main/kotlin/org/pareto/music/rehearse/Compiler.kt
@@ -7,6 +7,7 @@ import org.pareto.music.Decision
 import org.pareto.music.Melody
 import org.pareto.music.Harmony
 import org.pareto.music.Note
+import org.pareto.music.Silence
 
 
 typealias Deferred<T> = () -> T

--- a/src/main/kotlin/org/pareto/music/rehearse/README.md
+++ b/src/main/kotlin/org/pareto/music/rehearse/README.md
@@ -1,0 +1,17 @@
+# `music.rehearse`
+
+This package contains tools for compiling `Music` into intermediate representations.
+
+If you wanted to assign a thematically-correct type signature to this package, it would be:
+
+
+```kotlin
+typealias Rehearsable<T> = (Music) -> (T) -> Any?
+```
+
+
+You can contrast this with the [music.perform](../perform) package, which contains tools for directly running `Music`:
+
+```kotlin
+typealias Performable = (Music) -> Any?
+```

--- a/src/test/kotlin/org/pareto/music/DSLSpec.kt
+++ b/src/test/kotlin/org/pareto/music/DSLSpec.kt
@@ -3,6 +3,9 @@ package org.pareto.music
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.pareto.music.canon.GrammarBuilder
+import org.pareto.music.canon.compose
+import org.pareto.music.canon.extend
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertNull

--- a/src/test/kotlin/org/pareto/music/FunctionSpec.kt
+++ b/src/test/kotlin/org/pareto/music/FunctionSpec.kt
@@ -3,6 +3,8 @@ package org.pareto.music
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.pareto.music.canon.canonical
+import org.pareto.music.canon.compose
 import org.pareto.music.perform.Decider
 import org.pareto.music.perform.StringBuilderPerformer
 import org.pareto.music.rehearse.thread_validator.Program

--- a/src/test/kotlin/org/pareto/music/GrammarSpec.kt
+++ b/src/test/kotlin/org/pareto/music/GrammarSpec.kt
@@ -1,10 +1,12 @@
 package org.pareto.music
 
-import org.pareto.music.StdLib.Possible
+import org.pareto.music.canon.StdLib.Possible
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.pareto.music.canon.canonical
+import org.pareto.music.canon.compose
 import kotlin.test.assertEquals
 
 

--- a/src/test/kotlin/org/pareto/music/PlayerSpec.kt
+++ b/src/test/kotlin/org/pareto/music/PlayerSpec.kt
@@ -1,5 +1,6 @@
 package org.pareto.music
 
+import org.pareto.music.canon.compose
 import org.pareto.music.perform.Decider
 import org.pareto.music.perform.StringBuilderPerformer
 import kotlin.test.Test

--- a/src/test/kotlin/org/pareto/music/ProgramSpec.kt
+++ b/src/test/kotlin/org/pareto/music/ProgramSpec.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.pareto.music.canon.compose
 import org.pareto.music.rehearse.thread_validator.Program
 import java.lang.IllegalArgumentException
 

--- a/src/test/kotlin/org/pareto/music/StandardLibrarySpec.kt
+++ b/src/test/kotlin/org/pareto/music/StandardLibrarySpec.kt
@@ -3,13 +3,14 @@
 package org.pareto.music
 
 import org.pareto.music.Keyword.END
-import org.pareto.music.StdLib.OneOrMore
-import org.pareto.music.StdLib.Possible
-import org.pareto.music.StdLib.Repeating
-import org.pareto.music.StdLib.ZeroOrMore
+import org.pareto.music.canon.StdLib.OneOrMore
+import org.pareto.music.canon.StdLib.Possible
+import org.pareto.music.canon.StdLib.Repeating
+import org.pareto.music.canon.StdLib.ZeroOrMore
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
+import org.pareto.music.canon.compose
 import org.pareto.music.rehearse.thread_validator.Program
 import kotlin.test.Test
 import kotlin.test.todo

--- a/src/test/kotlin/org/pareto/music/feature_requests/functions/MakeFunctionsWork.kt
+++ b/src/test/kotlin/org/pareto/music/feature_requests/functions/MakeFunctionsWork.kt
@@ -6,11 +6,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.pareto.music.Fn
 import org.pareto.music.Grammar
-import org.pareto.music.GrammarBuilder
+import org.pareto.music.canon.GrammarBuilder
 import org.pareto.music.Music
 import org.pareto.music.Note
-import org.pareto.music.StdLib
-import org.pareto.music.compose
+import org.pareto.music.canon.StdLib
+import org.pareto.music.canon.compose
 import org.pareto.music.perform.Decider
 import org.pareto.music.perform.StringBuilderPerformer
 import org.pareto.music.feature_requests.FeatureRequest


### PR DESCRIPTION
1. add "music.canon" with DSL, StdLib, and "canonical" string representations (formerly included in Music.kt).
2. add READMEs for all packages.